### PR TITLE
feat: add backend GPT Actions CRUD API for CV management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Project scope
+
+This directory contains the Django / Django REST Framework backend for the CV project. Agents working in this repository must only modify files inside `backend/` (specifically `curriculum-backend/` in this repository) unless the user explicitly requests otherwise.
+
+## Development rules
+
+- Do not modify `frontend/` (specifically `curriculum-frontend/`) files.
+- Keep changes focused and minimal.
+- Prefer small, reviewable pull requests.
+- Do not commit secrets, tokens, API keys, credentials, database dumps, local `.env` values, or generated private files.
+- Do not change public API behavior unless the task explicitly requires it.
+- Do not perform broad refactors unrelated to the task.
+- Follow the existing Django app structure and naming conventions.
+- Add tests for security-sensitive behavior.
+- Run the backend test/check commands before opening a PR when possible.
+
+## Django / DRF conventions
+
+- Keep authentication and permission logic explicit.
+- Use serializers to whitelist editable fields.
+- Never trust client-provided ownership fields such as `user`, `profile`, or `user_profile`.
+- Scope querysets by the authenticated user when exposing private resources.
+- Return 404 for resources outside the authenticated user's scope.
+- Keep OpenAPI schemas accurate and stable when adding API endpoints.
+
+## GPT Actions integration conventions
+
+- GPT Actions endpoints must live under `/gpt-actions/`.
+- GPT Actions endpoints must require authentication.
+- GPT Actions endpoints must accept `Authorization: Bearer <token>`.
+- GPT Actions serializers must expose only fields that ChatGPT is allowed to edit.
+- GPT Actions endpoints must not expose media upload fields, admin-only fields, authentication endpoints, comments, contact/email endpoints, or unrelated app data.
+- Use clear and stable OpenAPI `operationId` values.

--- a/cv_backend/cv_backend/settings.py
+++ b/cv_backend/cv_backend/settings.py
@@ -39,6 +39,7 @@ PUBLIC_PROFILE_USERNAME = config('PUBLIC_PROFILE_USERNAME', default='')
 # Application definition
 
 INSTALLED_APPS = [
+    'gpt_actions',
     'email_service',
     'corsheaders',
     'rest_framework',

--- a/cv_backend/cv_backend/urls.py
+++ b/cv_backend/cv_backend/urls.py
@@ -43,6 +43,7 @@ schema_view = get_schema_view(
 
 
 urlpatterns = [
+    path('gpt-actions/', include('gpt_actions.urls')),
     path('', include('core.urls')),
     path('admin/', admin.site.urls),
     path("ckeditor5/", include('django_ckeditor_5.urls'), name="ck_editor_5_upload_file"),

--- a/cv_backend/gpt_actions/__init__.py
+++ b/cv_backend/gpt_actions/__init__.py
@@ -1,0 +1,1 @@
+# Init file for gpt_actions Django app

--- a/cv_backend/gpt_actions/apps.py
+++ b/cv_backend/gpt_actions/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class GptActionsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'gpt_actions'

--- a/cv_backend/gpt_actions/authentication.py
+++ b/cv_backend/gpt_actions/authentication.py
@@ -1,0 +1,9 @@
+from rest_framework.authentication import TokenAuthentication
+
+class BearerTokenAuthentication(TokenAuthentication):
+    """
+    Custom Token Authentication class that accepts the 'Bearer' keyword
+    instead of the default 'Token' keyword, making it fully compatible
+    with ChatGPT's standard GPT Actions API Key authorization.
+    """
+    keyword = 'Bearer'

--- a/cv_backend/gpt_actions/serializers.py
+++ b/cv_backend/gpt_actions/serializers.py
@@ -1,0 +1,103 @@
+from rest_framework import serializers
+from base_user.models import UserProfile
+from experiencia_laboral.models import ExperienciaLaboral
+from projects.models import Project
+from education_and_skills.models import Education, Skill, Course
+
+class GPTOwnedModelSerializer(serializers.ModelSerializer):
+    """
+    Base serializer that hides ownership fields since ownership is
+    determined strictly by the authenticated user's profile in the views.
+    """
+    pass
+
+class GPTUserProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = UserProfile
+        fields = [
+            'id',
+            'nombre',
+            'apellido',
+            'correo_electronico',
+            'resumen_habilidades',
+            'description',
+            'profesion',
+            'ciudad',
+            'direccion',
+            'telefono',
+            'edad',
+            'disponibilidad',
+        ]
+        read_only_fields = ['id']
+
+class GPTExperienciaLaboralSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ExperienciaLaboral
+        fields = [
+            'id',
+            'empresa',
+            'posicion',
+            'descripcion',
+            'fecha_inicio',
+            'fecha_fin',
+            'ubicacion',
+            'publicado',
+        ]
+        read_only_fields = ['id']
+
+class GPTProjectSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Project
+        fields = [
+            'id',
+            'title',
+            'description',
+            'start_date',
+            'end_date',
+            'link',
+            'order',
+        ]
+        read_only_fields = ['id']
+
+class GPTEducationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Education
+        fields = [
+            'id',
+            'title',
+            'subtitle',
+            'institution',
+            'start_year',
+            'end_year',
+            'description',
+        ]
+        read_only_fields = ['id']
+
+class GPTSkillSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Skill
+        fields = [
+            'id',
+            'title',
+            'category',
+            'proficiency',
+        ]
+        read_only_fields = ['id']
+
+    def validate_proficiency(self, value):
+        if value < 0 or value > 100:
+            raise serializers.ValidationError("Proficiency must be between 0 and 100.")
+        return value
+
+class GPTCourseSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Course
+        fields = [
+            'id',
+            'title',
+            'platform',
+            'completion_year',
+            'certificate_url',
+            'description',
+        ]
+        read_only_fields = ['id']

--- a/cv_backend/gpt_actions/tests.py
+++ b/cv_backend/gpt_actions/tests.py
@@ -1,0 +1,337 @@
+from datetime import date
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework.authtoken.models import Token
+from base_user.models import CustomUser, UserProfile
+from experiencia_laboral.models import ExperienciaLaboral
+from projects.models import Project
+from education_and_skills.models import Education, Skill, Course
+
+class GPTActionsTestCase(APITestCase):
+
+    def setUp(self):
+        # 1. Create a Primary Test User & Profile
+        self.user1 = CustomUser.objects.create_user(
+            username='yampi_admin',
+            email='yampi@example.com',
+            password='testpassword123',
+            role='admin'
+        )
+        # Ensure profile1 exists and has set values
+        self.profile1, _ = UserProfile.objects.get_or_create(user=self.user1)
+        self.profile1.nombre = 'Yampi'
+        self.profile1.apellido = 'Developer'
+        self.profile1.correo_electronico = 'yampi@example.com'
+        self.profile1.profesion = 'programador_web'
+        self.profile1.ciudad = 'Madrid'
+        self.profile1.disponibilidad = True
+        self.profile1.save()
+        self.token1, _ = Token.objects.get_or_create(user=self.user1)
+
+        # 2. Create an Impersonator/Second Test User & Profile for Isolation Testing
+        self.user2 = CustomUser.objects.create_user(
+            username='other_user',
+            email='other@example.com',
+            password='otherpassword123',
+            role='guest'
+        )
+        # Ensure profile2 exists and has set values
+        self.profile2, _ = UserProfile.objects.get_or_create(user=self.user2)
+        self.profile2.nombre = 'Other'
+        self.profile2.apellido = 'User'
+        self.profile2.correo_electronico = 'other@example.com'
+        self.profile2.profesion = 'programador_mobile'
+        self.profile2.ciudad = 'Barcelona'
+        self.profile2.disponibilidad = False
+        self.profile2.save()
+        self.token2, _ = Token.objects.get_or_create(user=self.user2)
+
+        # Set up default credentials for user1
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.token1.key}')
+
+    def test_authentication_required(self):
+        """
+        Verify that requests without any authorization header return 401.
+        """
+        self.client.credentials()  # Clear credentials
+        url = reverse('gpt-profile')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_authentication_with_invalid_token(self):
+        """
+        Verify that requests with an invalid/malformed token return 401.
+        """
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer invalid_token_12345')
+        url = reverse('gpt-profile')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_authentication_with_valid_token(self):
+        """
+        Verify that requests with a valid token succeed.
+        """
+        url = reverse('gpt-profile')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['nombre'], 'Yampi')
+
+    def test_profile_retrieve_and_update(self):
+        """
+        Verify profile retrieve and patch behavior.
+        """
+        url = reverse('gpt-profile')
+        
+        # 1. Retrieve profile
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['ciudad'], 'Madrid')
+        
+        # 2. Update profile (PATCH)
+        update_data = {
+            'ciudad': 'Valencia',
+            'nombre': 'Yampi Updated',
+            'profesion': 'programador_mobile'
+        }
+        response = self.client.patch(url, update_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.profile1.refresh_from_db()
+        self.assertEqual(self.profile1.ciudad, 'Valencia')
+        self.assertEqual(self.profile1.nombre, 'Yampi Updated')
+        self.assertEqual(self.profile1.profesion, 'programador_mobile')
+
+    def test_experience_crud_and_soft_delete(self):
+        """
+        Verify complete CRUD on ExperienciaLaboral.
+        Ensures creation auto-associates with user1, detail isolation, and soft delete behavior.
+        """
+        # Create user1 experience
+        url_list = reverse('gpt-experiences-list')
+        experience_data = {
+            'empresa': 'Acme Corp',
+            'posicion': 'Backend Developer',
+            'descripcion': '<p>Developing APIs</p>',
+            'fecha_inicio': '2024-01-01',
+            'ubicacion': 'Madrid',
+            'publicado': True
+        }
+        response = self.client.post(url_list, experience_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experience_id = response.data['id']
+        
+        # Verify it was linked to profile1
+        exp_obj = ExperienciaLaboral.objects.get(id=experience_id)
+        self.assertEqual(exp_obj.user_profile, self.profile1)
+
+        # Create user2 experience to test isolation
+        other_exp = ExperienciaLaboral.objects.create(
+            user_profile=self.profile2,
+            empresa='Other Corp',
+            posicion='iOS Developer',
+            fecha_inicio=date(2023, 5, 1),
+            ubicacion='Barcelona',
+            publicado=True
+        )
+
+        # List experiences (should only return user1's experience)
+        response = self.client.get(url_list)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['empresa'], 'Acme Corp')
+
+        # Retrieve detail of own experience
+        url_detail = reverse('gpt-experiences-detail', kwargs={'pk': experience_id})
+        response = self.client.get(url_detail)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['empresa'], 'Acme Corp')
+
+        # Retrieve detail of other user's experience (should return 404)
+        url_other_detail = reverse('gpt-experiences-detail', kwargs={'pk': other_exp.id})
+        response = self.client.get(url_other_detail)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Update own experience (PATCH)
+        response = self.client.patch(url_detail, {'empresa': 'Acme Inc.'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        exp_obj.refresh_from_db()
+        self.assertEqual(exp_obj.empresa, 'Acme Inc.')
+
+        # Update other user's experience (PATCH should return 404)
+        response = self.client.patch(url_other_detail, {'empresa': 'Hacked'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        other_exp.refresh_from_db()
+        self.assertEqual(other_exp.empresa, 'Other Corp')
+
+        # Delete own experience (should perform SOFT delete, i.e., set publicado=False and return 204)
+        response = self.client.delete(url_detail)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        exp_obj.refresh_from_db()
+        self.assertFalse(exp_obj.publicado)
+
+        # Delete other user's experience (DELETE should return 404)
+        response = self.client.delete(url_other_detail)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_projects_isolation_and_hard_delete(self):
+        """
+        Verify isolation and hard delete on Project.
+        """
+        own_project = Project.objects.create(
+            user_profile=self.profile1,
+            title='My Portfolio',
+            start_date=date(2023, 1, 1),
+            order=1
+        )
+        other_project = Project.objects.create(
+            user_profile=self.profile2,
+            title='Other Project',
+            start_date=date(2023, 2, 1),
+            order=2
+        )
+
+        url_list = reverse('gpt-projects-list')
+        url_detail = reverse('gpt-projects-detail', kwargs={'pk': own_project.id})
+        url_other = reverse('gpt-projects-detail', kwargs={'pk': other_project.id})
+
+        # List
+        response = self.client.get(url_list)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['title'], 'My Portfolio')
+
+        # Retrieve other project
+        response = self.client.get(url_other)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Hard delete own project
+        response = self.client.delete(url_detail)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Project.objects.filter(id=own_project.id).exists())
+
+    def test_education_isolation_and_hard_delete(self):
+        """
+        Verify isolation and hard delete on Education.
+        """
+        own_edu = Education.objects.create(
+            user_profile=self.profile1,
+            title='Computer Science Degree',
+            institution='UAM',
+            start_year=2018,
+            end_year=2022
+        )
+        other_edu = Education.objects.create(
+            user_profile=self.profile2,
+            title='Art History',
+            institution='UCM',
+            start_year=2015,
+            end_year=2019
+        )
+
+        url_list = reverse('gpt-education-list')
+        url_detail = reverse('gpt-education-detail', kwargs={'pk': own_edu.id})
+        url_other = reverse('gpt-education-detail', kwargs={'pk': other_edu.id})
+
+        # List
+        response = self.client.get(url_list)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['title'], 'Computer Science Degree')
+
+        # Retrieve other edu
+        response = self.client.get(url_other)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Hard delete
+        response = self.client.delete(url_detail)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Education.objects.filter(id=own_edu.id).exists())
+
+    def test_skills_isolation_and_proficiency_validation(self):
+        """
+        Verify isolation, proficiency limit validation, and hard delete on Skill.
+        """
+        own_skill = Skill.objects.create(
+            user_profile=self.profile1,
+            title='Python',
+            category='backend',
+            proficiency=90
+        )
+        other_skill = Skill.objects.create(
+            user_profile=self.profile2,
+            title='React',
+            category='frontend',
+            proficiency=80
+        )
+
+        url_list = reverse('gpt-skills-list')
+        url_detail = reverse('gpt-skills-detail', kwargs={'pk': own_skill.id})
+        url_other = reverse('gpt-skills-detail', kwargs={'pk': other_skill.id})
+
+        # List
+        response = self.client.get(url_list)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['title'], 'Python')
+
+        # Retrieve other
+        response = self.client.get(url_other)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Create skill validation error (proficiency = 120)
+        invalid_skill_data = {
+            'title': 'Rust',
+            'category': 'backend',
+            'proficiency': 120
+        }
+        response = self.client.post(url_list, invalid_skill_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('proficiency', response.data)
+
+        # Hard delete
+        response = self.client.delete(url_detail)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Skill.objects.filter(id=own_skill.id).exists())
+
+    def test_courses_isolation_and_hard_delete(self):
+        """
+        Verify isolation and hard delete on Course.
+        """
+        own_course = Course.objects.create(
+            user_profile=self.profile1,
+            title='Django Advanced',
+            platform='Udemy',
+            completion_year=2024
+        )
+        other_course = Course.objects.create(
+            user_profile=self.profile2,
+            title='Swift Fundamentals',
+            platform='Platzi',
+            completion_year=2023
+        )
+
+        url_list = reverse('gpt-courses-list')
+        url_detail = reverse('gpt-courses-detail', kwargs={'pk': own_course.id})
+        url_other = reverse('gpt-courses-detail', kwargs={'pk': other_course.id})
+
+        # List
+        response = self.client.get(url_list)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['title'], 'Django Advanced')
+
+        # Retrieve other
+        response = self.client.get(url_other)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Hard delete
+        response = self.client.delete(url_detail)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Course.objects.filter(id=own_course.id).exists())
+
+    def test_openapi_schema_endpoint(self):
+        """
+        Verify that the schema view serves the YAML file correctly without authentication.
+        """
+        self.client.credentials()  # Clear credentials to test anonymous access
+        url = reverse('gpt-schema')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('text/yaml', response['Content-Type'])
+        self.assertIn(b'Private CV Management API', response.content)

--- a/cv_backend/gpt_actions/urls.py
+++ b/cv_backend/gpt_actions/urls.py
@@ -1,0 +1,25 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+
+from .views import (
+    GPTProfileView,
+    GPTExperienceViewSet,
+    GPTProjectViewSet,
+    GPTEducationViewSet,
+    GPTSkillViewSet,
+    GPTCourseViewSet,
+    GPTOpenAPISchemaView,
+)
+
+router = DefaultRouter()
+router.register("experiences", GPTExperienceViewSet, basename="gpt-experiences")
+router.register("projects", GPTProjectViewSet, basename="gpt-projects")
+router.register("education", GPTEducationViewSet, basename="gpt-education")
+router.register("skills", GPTSkillViewSet, basename="gpt-skills")
+router.register("courses", GPTCourseViewSet, basename="gpt-courses")
+
+urlpatterns = [
+    path("profile/", GPTProfileView.as_view(), name="gpt-profile"),
+    path("schema/", GPTOpenAPISchemaView.as_view(), name="gpt-schema"),
+    path("", include(router.urls)),
+]

--- a/cv_backend/gpt_actions/views.py
+++ b/cv_backend/gpt_actions/views.py
@@ -1,0 +1,121 @@
+import os
+from django.conf import settings
+from django.http import HttpResponse, Http404
+from rest_framework import viewsets, generics, status
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.response import Response
+
+from base_user.models import UserProfile
+from experiencia_laboral.models import ExperienciaLaboral
+from projects.models import Project
+from education_and_skills.models import Education, Skill, Course
+
+from .authentication import BearerTokenAuthentication
+from .serializers import (
+    GPTUserProfileSerializer,
+    GPTExperienciaLaboralSerializer,
+    GPTProjectSerializer,
+    GPTEducationSerializer,
+    GPTSkillSerializer,
+    GPTCourseSerializer,
+)
+
+class GPTAuthMixin:
+    """
+    Ensures endpoints are strictly protected by Bearer token authentication.
+    """
+    authentication_classes = [BearerTokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+class GPTOwnedProfileMixin(GPTAuthMixin):
+    """
+    Ensures that querysets are strictly scoped to the authenticated user's profile
+    and that newly created items are automatically linked to that profile.
+    """
+    model = None
+
+    def get_profile(self):
+        if not hasattr(self.request.user, 'profile') or self.request.user.profile is None:
+            raise Http404("UserProfile does not exist for the authenticated user.")
+        return self.request.user.profile
+
+    def get_queryset(self):
+        profile = self.get_profile()
+        return self.model.objects.filter(user_profile=profile)
+
+    def perform_create(self, serializer):
+        serializer.save(user_profile=self.get_profile())
+
+class GPTProfileView(GPTAuthMixin, generics.RetrieveUpdateAPIView):
+    """
+    View to retrieve and partially/fully update the authenticated user's profile.
+    """
+    serializer_class = GPTUserProfileSerializer
+
+    def get_object(self):
+        if not hasattr(self.request.user, 'profile') or self.request.user.profile is None:
+            raise Http404("UserProfile does not exist for the authenticated user.")
+        return self.request.user.profile
+
+class GPTExperienceViewSet(GPTOwnedProfileMixin, viewsets.ModelViewSet):
+    """
+    CRUD for Work Experiences.
+    Performs a soft delete (sets 'publicado' to False) instead of hard deletion.
+    """
+    model = ExperienciaLaboral
+    serializer_class = GPTExperienciaLaboralSerializer
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        instance.publicado = False
+        instance.save()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+class GPTProjectViewSet(GPTOwnedProfileMixin, viewsets.ModelViewSet):
+    """
+    CRUD for Portfolio Projects.
+    Performs standard hard delete.
+    """
+    model = Project
+    serializer_class = GPTProjectSerializer
+
+class GPTEducationViewSet(GPTOwnedProfileMixin, viewsets.ModelViewSet):
+    """
+    CRUD for Formal Education.
+    Performs standard hard delete.
+    """
+    model = Education
+    serializer_class = GPTEducationSerializer
+
+class GPTSkillViewSet(GPTOwnedProfileMixin, viewsets.ModelViewSet):
+    """
+    CRUD for Habilities/Skills.
+    Performs standard hard delete.
+    """
+    model = Skill
+    serializer_class = GPTSkillSerializer
+
+class GPTCourseViewSet(GPTOwnedProfileMixin, viewsets.ModelViewSet):
+    """
+    CRUD for Courses.
+    Performs standard hard delete.
+    """
+    model = Course
+    serializer_class = GPTCourseSerializer
+
+class GPTOpenAPISchemaView(APIView):
+    """
+    Serves the static OpenAPI schema YAML file for ChatGPT Actions configuration.
+    """
+    permission_classes = [AllowAny]
+
+    def get(self, request, *args, **kwargs):
+        schema_path = os.path.join(settings.BASE_DIR, '..', 'docs', 'gpt-actions-openapi.yaml')
+        if not os.path.exists(schema_path):
+            raise Http404("OpenAPI schema file not found.")
+        
+        with open(schema_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+            
+        return HttpResponse(content, content_type='text/yaml')

--- a/docs/gpt-actions-openapi.yaml
+++ b/docs/gpt-actions-openapi.yaml
@@ -1,0 +1,777 @@
+openapi: 3.0.0
+info:
+  title: Private CV Management API (GPT Actions)
+  version: 1.0.0
+  description: API privada segura para leer y editar los datos del CV de Yampi usando un Custom GPT de ChatGPT.
+
+servers:
+  - url: https://YOUR_BACKEND_DOMAIN/gpt-actions
+    description: Servidor de producción (reemplazar con el dominio real)
+
+security:
+  - BearerAuth: []
+
+paths:
+  /profile/:
+    get:
+      operationId: getProfile
+      summary: Obtiene el perfil profesional del usuario autenticado.
+      description: Recupera los datos principales del perfil (nombre, correo, profesión, resumen, etc.).
+      responses:
+        '200':
+          description: Perfil recuperado con éxito.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+        '401':
+          description: No autorizado.
+
+    patch:
+      operationId: updateProfile
+      summary: Actualiza parcialmente el perfil profesional del usuario.
+      description: Modifica solo los campos proporcionados del perfil (por ejemplo, el resumen profesional o la profesión).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserProfile'
+      responses:
+        '200':
+          description: Perfil actualizado correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserProfile'
+        '400':
+          description: Datos de entrada no válidos.
+        '401':
+          description: No autorizado.
+
+  /experiences/:
+    get:
+      operationId: listExperiences
+      summary: Lista las experiencias laborales del usuario autenticado.
+      description: Devuelve un listado completo de los puestos de trabajo y empresas.
+      responses:
+        '200':
+          description: Listado recuperado con éxito.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExperienciaLaboral'
+        '401':
+          description: No autorizado.
+
+    post:
+      operationId: createExperience
+      summary: Crea una nueva experiencia laboral.
+      description: Añade una experiencia laboral asociada automáticamente al perfil del usuario autenticado.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExperienciaLaboralInput'
+      responses:
+        '201':
+          description: Creado correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperienciaLaboral'
+        '400':
+          description: Error de validación.
+        '401':
+          description: No autorizado.
+
+  /experiences/{id}/:
+    get:
+      operationId: getExperience
+      summary: Obtiene los detalles de una experiencia laboral específica.
+      description: Recupera un único registro por su ID numérico si pertenece al usuario.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Registro recuperado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperienciaLaboral'
+        '401':
+          description: No autorizado.
+        '404':
+          description: No encontrado o no pertenece al usuario.
+
+    patch:
+      operationId: updateExperience
+      summary: Actualiza parcialmente una experiencia laboral.
+      description: Modifica los campos que se pasen en el JSON para el registro indicado.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExperienciaLaboralInput'
+      responses:
+        '200':
+          description: Actualizado correctamente.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperienciaLaboral'
+        '401':
+          description: No autorizado.
+        '404':
+          description: No encontrado.
+
+    delete:
+      operationId: deleteExperience
+      summary: Elimina una experiencia laboral (Soft Delete).
+      description: Oculta la experiencia laboral del CV configurando 'publicado = False' en lugar de borrar físicamente el registro.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Borrado lógico aplicado con éxito (sin contenido).
+        '401':
+          description: No autorizado.
+        '404':
+          description: No encontrado.
+
+  /projects/:
+    get:
+      operationId: listProjects
+      summary: Lista los proyectos de portafolio del usuario autenticado.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+
+    post:
+      operationId: createProject
+      summary: Crea un nuevo proyecto.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectInput'
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+
+  /projects/{id}/:
+    get:
+      operationId: getProject
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+        '404':
+          description: No encontrado.
+
+    patch:
+      operationId: updateProject
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProjectInput'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+        '404':
+          description: No encontrado.
+
+    delete:
+      operationId: deleteProject
+      summary: Elimina permanentemente un proyecto (Hard Delete).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Eliminado físicamente de la base de datos.
+        '404':
+          description: No encontrado.
+
+  /education/:
+    get:
+      operationId: listEducation
+      summary: Lista las formaciones y educación formal del usuario autenticado.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Education'
+
+    post:
+      operationId: createEducation
+      summary: Crea un nuevo registro de educación.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EducationInput'
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Education'
+
+  /education/{id}/:
+    get:
+      operationId: getEducation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Education'
+        '404':
+          description: No encontrado.
+
+    patch:
+      operationId: updateEducation
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EducationInput'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Education'
+        '404':
+          description: No encontrado.
+
+    delete:
+      operationId: deleteEducation
+      summary: Elimina físicamente un registro de educación (Hard Delete).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Eliminado.
+        '404':
+          description: No encontrado.
+
+  /skills/:
+    get:
+      operationId: listSkills
+      summary: Lista las habilidades del usuario autenticado.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Skill'
+
+    post:
+      operationId: createSkill
+      summary: Añade una nueva habilidad.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SkillInput'
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Skill'
+
+  /skills/{id}/:
+    get:
+      operationId: getSkill
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Skill'
+        '404':
+          description: No encontrado.
+
+    patch:
+      operationId: updateSkill
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SkillInput'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Skill'
+        '404':
+          description: No encontrado.
+
+    delete:
+      operationId: deleteSkill
+      summary: Elimina físicamente una habilidad (Hard Delete).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Eliminada.
+        '404':
+          description: No encontrado.
+
+  /courses/:
+    get:
+      operationId: listCourses
+      summary: Lista los cursos no formales realizados por el usuario autenticado.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
+
+    post:
+      operationId: createCourse
+      summary: Registra un nuevo curso.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CourseInput'
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+
+  /courses/{id}/:
+    get:
+      operationId: getCourse
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+        '404':
+          description: No encontrado.
+
+    patch:
+      operationId: updateCourse
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CourseInput'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+        '404':
+          description: No encontrado.
+
+    delete:
+      operationId: deleteCourse
+      summary: Elimina físicamente un curso registrado (Hard Delete).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Eliminado.
+        '404':
+          description: No encontrado.
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: Pega tu Bearer Token de Django REST Framework para autenticarte.
+
+  schemas:
+    UserProfile:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        nombre:
+          type: string
+          nullable: true
+        apellido:
+          type: string
+          nullable: true
+        correo_electronico:
+          type: string
+          format: email
+          nullable: true
+        resumen_habilidades:
+          type: string
+          description: Resumen en formato HTML o texto plano.
+          nullable: true
+        description:
+          type: string
+          description: Descripción personal en HTML o texto plano.
+          nullable: true
+        profesion:
+          type: string
+          enum: [programador_web, administrador_sistemas, programador_mobile]
+          description: Profesión principal elegida.
+        ciudad:
+          type: string
+          nullable: true
+        direccion:
+          type: string
+          nullable: true
+        telefono:
+          type: string
+          nullable: true
+        edad:
+          type: integer
+          nullable: true
+        disponibilidad:
+          type: boolean
+          description: Indica si el usuario está disponible para trabajar.
+
+    ExperienciaLaboral:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        empresa:
+          type: string
+        posicion:
+          type: string
+        descripcion:
+          type: string
+          description: Detalles de tus labores en formato HTML o texto plano.
+          nullable: true
+        fecha_inicio:
+          type: string
+          format: date
+          description: Fecha de inicio en formato YYYY-MM-DD.
+        fecha_fin:
+          type: string
+          format: date
+          description: Fecha de finalización en formato YYYY-MM-DD. Dejar nulo si es tu trabajo actual.
+          nullable: true
+        ubicacion:
+          type: string
+        publicado:
+          type: boolean
+          description: Determina si se muestra o no esta experiencia en el CV público.
+
+    ExperienciaLaboralInput:
+      type: object
+      required:
+        - empresa
+        - posicion
+        - fecha_inicio
+        - ubicacion
+      properties:
+        empresa:
+          type: string
+        posicion:
+          type: string
+        descripcion:
+          type: string
+        fecha_inicio:
+          type: string
+          format: date
+          description: Formato obligatorio YYYY-MM-DD.
+        fecha_fin:
+          type: string
+          format: date
+          description: Formato obligatorio YYYY-MM-DD. Dejar nulo o no enviar si es actual.
+          nullable: true
+        ubicacion:
+          type: string
+        publicado:
+          type: boolean
+
+    Project:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+        description:
+          type: string
+          nullable: true
+        start_date:
+          type: string
+          format: date
+          description: YYYY-MM-DD
+        end_date:
+          type: string
+          format: date
+          description: YYYY-MM-DD
+          nullable: true
+        link:
+          type: string
+          format: uri
+          nullable: true
+        order:
+          type: integer
+
+    ProjectInput:
+      type: object
+      required:
+        - title
+        - start_date
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        start_date:
+          type: string
+          format: date
+          description: Formato obligatorio YYYY-MM-DD.
+        end_date:
+          type: string
+          format: date
+          description: Formato obligatorio YYYY-MM-DD.
+          nullable: true
+        link:
+          type: string
+          format: uri
+          nullable: true
+        order:
+          type: integer
+
+    Education:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+        subtitle:
+          type: string
+          nullable: true
+        institution:
+          type: string
+        start_year:
+          type: integer
+        end_year:
+          type: integer
+          nullable: true
+        description:
+          type: string
+          nullable: true
+
+    EducationInput:
+      type: object
+      required:
+        - title
+        - institution
+        - start_year
+      properties:
+        title:
+          type: string
+        subtitle:
+          type: string
+        institution:
+          type: string
+        start_year:
+          type: integer
+        end_year:
+          type: integer
+          nullable: true
+        description:
+          type: string
+
+    Skill:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+        category:
+          type: string
+          enum: [frontend, backend, mobile, sysadmin, office, other]
+        proficiency:
+          type: integer
+          description: Porcentaje de maestría en la habilidad (0 a 100).
+
+    SkillInput:
+      type: object
+      required:
+        - title
+        - category
+        - proficiency
+      properties:
+        title:
+          type: string
+        category:
+          type: string
+          enum: [frontend, backend, mobile, sysadmin, office, other]
+        proficiency:
+          type: integer
+          minimum: 0
+          maximum: 100
+
+    Course:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        title:
+          type: string
+        platform:
+          type: string
+          enum: [Udemy, Platzi, OPENWEBINARS, SEPE]
+        completion_year:
+          type: integer
+        certificate_url:
+          type: string
+          format: uri
+          nullable: true
+        description:
+          type: string
+          nullable: true
+
+    CourseInput:
+      type: object
+      required:
+        - title
+        - platform
+        - completion_year
+      properties:
+        title:
+          type: string
+        platform:
+          type: string
+          enum: [Udemy, Platzi, OPENWEBINARS, SEPE]
+        completion_year:
+          type: integer
+        certificate_url:
+          type: string
+          format: uri
+          nullable: true
+        description:
+          type: string

--- a/docs/gpt-actions.md
+++ b/docs/gpt-actions.md
@@ -1,0 +1,115 @@
+# Integración de ChatGPT con GPT Actions para la Gestión de CV
+
+Esta documentación describe cómo integrar tu **Custom GPT privado** de ChatGPT con el backend de tu CV para permitir consultas y modificaciones (CRUD) en tiempo real de tus datos profesionales mediante lenguaje natural.
+
+---
+
+## 1. Arquitectura y Seguridad
+
+- **URL Base**: `/gpt-actions/`
+- **Autenticación**: Cabecera `Authorization: Bearer <token>`
+- **Aislamiento Estricto (Ownership)**: La API asocia automáticamente todas las lecturas y escrituras al `UserProfile` del usuario autenticado vía token. No es posible leer ni modificar datos de otros perfiles; de intentarse, el servidor responderá con código HTTP `404 Not Found` para proteger la privacidad.
+- **Campos Seguros**: No se exponen subidas de archivos ni campos de administración del sistema. Los campos se limitan a datos de texto, fechas y números.
+- **Estrategia de Borrado (DELETE)**:
+  - **Experiencia Laboral**: Realiza un **soft delete** (marcando `publicado = False` en lugar de eliminar el registro físico de la base de datos).
+  - **Proyectos, Educación, Skills y Cursos**: Realizan un **hard delete** (eliminación física permanente de la base de datos).
+
+---
+
+## 2. Cómo Obtener tu Token de Autenticación
+
+El backend utiliza el sistema nativo `rest_framework.authtoken` de Django REST Framework. Tienes dos maneras de obtener o generar tu Token:
+
+### Método A: Desde el Panel de Administración de Django
+1. Accede al panel de administración de Django (ej. `https://backend.yampi.eu/admin/`).
+2. Ve a la sección **Tokens** (bajo "AUTH TOKEN").
+3. Haz clic en **Añadir Token**, selecciona tu usuario y guarda.
+4. Copia la cadena alfanumérica generada (por ejemplo, `9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b`).
+
+### Método B: Desde la Consola de Django (Django Shell)
+Si tienes acceso a la terminal del servidor, puedes generarlo ejecutando:
+```bash
+python manage.py shell
+```
+Dentro de la consola interactiva de Python:
+```python
+from django.contrib.auth import get_user_model
+from rest_framework.authtoken.models import Token
+
+User = get_user_model()
+user = User.objects.get(username="tu_usuario")  # Reemplaza con tu usuario administrador
+token, created = Token.objects.get_or_create(user=user)
+print("Tu Token es:", token.key)
+```
+
+---
+
+## 3. Configuración de la Action en ChatGPT
+
+Para configurar tu Custom GPT privado con estas acciones, sigue estos pasos:
+
+1. Ve a [ChatGPT](https://chatgpt.com) y selecciona **Explore GPTs** -> **Create a GPT** (o edita uno existente).
+2. En la pestaña **Configure**, añade el nombre, descripción e instrucciones básicas.
+3. Haz clic en **Create new action** (Crear nueva acción) en la parte inferior.
+4. Configura los siguientes parámetros:
+   - **Authentication** (Autenticación):
+     - **Type**: `API Key`
+     - **Auth Type**: `Bearer`
+     - **API Key**: *[Pega el Token que obtuviste en el paso anterior]*
+   - **Schema**:
+     - Selecciona **Import from URL** y proporciona `https://tu-dominio.com/gpt-actions/schema/` o copia y pega el contenido completo de `curriculum-backend/docs/gpt-actions-openapi.yaml` directamente en el editor.
+5. Guarda la Action. Asegúrate de configurar la visibilidad de tu Custom GPT a **Only me** (Solo yo) o **Only people with a link** (Solo personas con el enlace) para mantener tu token y acceso completamente privado.
+
+---
+
+## 4. Instrucciones del Sistema recomendadas para el Custom GPT
+
+Copia y pega el siguiente bloque de instrucciones en la pestaña **Instructions** del editor de tu Custom GPT:
+
+```txt
+Eres el gestor privado del CV de Yampi. Tu propósito es ayudar al usuario a leer y modificar los datos profesionales de su currículum mediante lenguaje natural a través de las acciones API proporcionadas.
+
+Sigue rigurosamente estas pautas operativas:
+1. Usa las acciones exclusivamente para leer o modificar datos del CV.
+2. Antes de realizar cualquier acción de escritura (crear, actualizar o borrar registros), resume de forma clara y concisa el cambio exacto que vas a realizar y solicita confirmación explícita del usuario.
+3. No inventes fechas, empresas, tecnologías, ni identificadores (IDs).
+4. Cuando tengas que modificar o borrar un elemento existente (por ejemplo, una experiencia laboral, skill o proyecto), primero realiza una llamada de listado (GET) para identificar el registro correcto y su correspondiente ID numérico.
+5. Después de realizar una modificación exitosa, vuelve a consultar el recurso afectado para confirmar visualmente el resultado y reporta el cambio al usuario.
+6. El formato obligatorio para todos los campos de tipo fecha es estrictamente YYYY-MM-DD (por ejemplo, 2024-01-15). Transforma cualquier fecha relativa o difusa que te indique el usuario a este formato antes de enviarla.
+7. No intentes modificar campos de archivos multimedia, logos, PDFs o campos que no estén explícitamente expuestos en el schema OpenAPI.
+```
+
+---
+
+## 5. Endpoints Disponibles
+
+| Método | Endpoint | Acción | Operación OpenAPI (`operationId`) |
+| :--- | :--- | :--- | :--- |
+| **GET** | `/gpt-actions/profile/` | Leer perfil | `getProfile` |
+| **PATCH** | `/gpt-actions/profile/` | Actualizar perfil | `updateProfile` |
+| **GET** | `/gpt-actions/experiences/` | Listar experiencias | `listExperiences` |
+| **POST** | `/gpt-actions/experiences/` | Crear experiencia | `createExperience` |
+| **GET** | `/gpt-actions/experiences/{id}/` | Detalle experiencia | `getExperience` |
+| **PATCH** | `/gpt-actions/experiences/{id}/` | Actualizar experiencia | `updateExperience` |
+| **DELETE** | `/gpt-actions/experiences/{id}/` | Soft delete experiencia | `deleteExperience` |
+| **GET** | `/gpt-actions/projects/` | Listar proyectos | `listProjects` |
+| **POST** | `/gpt-actions/projects/` | Crear proyecto | `createProject` |
+| **GET** | `/gpt-actions/projects/{id}/` | Detalle proyecto | `getProject` |
+| **PATCH** | `/gpt-actions/projects/{id}/` | Actualizar proyecto | `updateProject` |
+| **DELETE** | `/gpt-actions/projects/{id}/` | Hard delete proyecto | `deleteProject` |
+| **GET** | `/gpt-actions/education/` | Listar educación | `listEducation` |
+| **POST** | `/gpt-actions/education/` | Crear educación | `createEducation` |
+| **GET** | `/gpt-actions/education/{id}/` | Detalle educación | `getEducation` |
+| **PATCH** | `/gpt-actions/education/{id}/` | Actualizar educación | `updateEducation` |
+| **DELETE** | `/gpt-actions/education/{id}/` | Hard delete educación | `deleteEducation` |
+| **GET** | `/gpt-actions/skills/` | Listar habilidades | `listSkills` |
+| **POST** | `/gpt-actions/skills/` | Crear habilidad | `createSkill` |
+| **GET** | `/gpt-actions/skills/{id}/` | Detalle habilidad | `getSkill` |
+| **PATCH** | `/gpt-actions/skills/{id}/` | Actualizar habilidad | `updateSkill` |
+| **DELETE** | `/gpt-actions/skills/{id}/` | Hard delete habilidad | `deleteSkill` |
+| **GET** | `/gpt-actions/courses/` | Listar cursos | `listCourses` |
+| **POST** | `/gpt-actions/courses/` | Crear curso | `createCourse` |
+| **GET** | `/gpt-actions/courses/{id}/` | Detalle curso | `getCourse` |
+| **PATCH** | `/gpt-actions/courses/{id}/` | Actualizar curso | `updateCourse` |
+| **DELETE** | `/gpt-actions/courses/{id}/` | Hard delete curso | `deleteCourse` |
+| **GET** | `/gpt-actions/schema/` | Obtener el OpenAPI YAML | *(Público, para importación)* |


### PR DESCRIPTION
## Summary
- Added backend-only `/gpt-actions/` API for ChatGPT GPT Actions.
- Added Bearer token authentication compatibility for GPT Actions endpoints.
- Added safe serializers and DRF views for profile, experiences, projects, education, skills, and courses.
- Added backend OpenAPI schema/docs for configuring a private Custom GPT.
- Added `backend/AGENTS.md` (specifically `curriculum-backend/AGENTS.md` in this repository) with Django/backend agent rules.
- Added tests for authentication, validation, and ownership isolation.

## Scope
- This PR only changes files under `curriculum-backend/`.
- No frontend files were modified.

## Security notes
- GPT Actions endpoints require Bearer token authentication.
- Querysets are scoped strictly to the authenticated user's profile.
- Ownership fields such as `user_profile`, `profile`, or `user` are never accepted from request payloads.
- Media/file fields are intentionally not exposed in this MVP.
- Resources outside the authenticated user's scope return 404.

## Testing
- [x] `cd curriculum-backend && python cv_backend/manage.py check` (Passed successfully)
- [x] `cd curriculum-backend && python cv_backend/manage.py test gpt_actions` (All 10 tests passed successfully)

## How to configure in ChatGPT
1. Create a private Custom GPT.
2. Go to Configure → Actions → Create new action.
3. Set Authentication to API Key / Bearer.
4. Paste a valid backend DRF token.
5. Import or paste `docs/gpt-actions-openapi.yaml` (which can also be fetched from the public endpoint `https://YOUR_BACKEND_DOMAIN/gpt-actions/schema/`).
